### PR TITLE
ログインユーザ詳細取得APIを実装

### DIFF
--- a/app/src/main/java/dev/abelab/hack/dena/api/controller/UserRestController.java
+++ b/app/src/main/java/dev/abelab/hack/dena/api/controller/UserRestController.java
@@ -11,6 +11,7 @@ import dev.abelab.hack.dena.annotation.Authenticated;
 import dev.abelab.hack.dena.db.entity.User;
 import dev.abelab.hack.dena.api.request.LoginUserPasswordUpdateRequest;
 import dev.abelab.hack.dena.service.UserService;
+import dev.abelab.hack.dena.api.response.UserResponse;
 
 @Api(tags = "User")
 @RestController
@@ -48,5 +49,31 @@ public class UserRestController {
     ) {
         this.userService.updateLoginPasswordUser(requestBody, loginUser);
     }
+
+    /**
+     * プロフィール取得API
+     *
+     * @param loginUser ログインユーザ
+     *
+     * @return ユーザ詳細レスポンス
+     */
+    @ApiOperation( //
+        value = "プロフィール取得", //
+        notes = "プロフィールを取得する。" //
+    )
+    @ApiResponses( //
+        value = { //
+                @ApiResponse(code = 200, message = "取得成功", response = UserResponse.class), //
+                @ApiResponse(code = 401, message = "ユーザがログインしていない"), //
+                @ApiResponse(code = 404, message = "ユーザが存在しない") //
+        })
+    @GetMapping(value = "/me")
+    @ResponseStatus(HttpStatus.OK)
+    public UserResponse getLoginUser( //
+        @ModelAttribute("LoginUser") final User loginUser //
+    ) {
+        return this.userService.getUserProfile(loginUser);
+    }
+
 
 }

--- a/app/src/main/java/dev/abelab/hack/dena/api/response/UserResponse.java
+++ b/app/src/main/java/dev/abelab/hack/dena/api/response/UserResponse.java
@@ -1,0 +1,34 @@
+package dev.abelab.hack.dena.api.response;
+
+import lombok.*;
+
+/**
+ * ユーザ情報レスポンス
+ */
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserResponse {
+
+    /**
+     * ユーザID
+     */
+    Integer id;
+
+    /**
+     * メールアドレス
+     */
+    String email;
+
+    /**
+     * ファーストネーム
+     */
+    String firstName;
+
+    /**
+     * ラストネーム
+     */
+    String lastName;
+
+}

--- a/app/src/main/java/dev/abelab/hack/dena/service/UserService.java
+++ b/app/src/main/java/dev/abelab/hack/dena/service/UserService.java
@@ -2,6 +2,8 @@ package dev.abelab.hack.dena.service;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.modelmapper.ModelMapper;
+
 
 import lombok.*;
 import dev.abelab.hack.dena.db.entity.User;
@@ -9,10 +11,13 @@ import dev.abelab.hack.dena.api.request.LoginUserPasswordUpdateRequest;
 import dev.abelab.hack.dena.repository.UserRepository;
 import dev.abelab.hack.dena.logic.UserLogic;
 import dev.abelab.hack.dena.util.AuthUtil;
+import dev.abelab.hack.dena.api.response.UserResponse;
 
 @RequiredArgsConstructor
 @Service
 public class UserService {
+
+    private final ModelMapper modelMapper;
 
     private final UserRepository userRepository;
 
@@ -36,5 +41,18 @@ public class UserService {
         loginUser.setPassword(this.userLogic.encodePassword(requestBody.getNewPassword()));
         this.userRepository.update(loginUser);
     }
+
+     /**
+     * プロフィール情報を取得
+     *
+     * @param loginUser ログインユーザ
+     *
+     * @return プロフィール情報レスポンス
+     */
+    @Transactional
+    public UserResponse getUserProfile(final User loginUser) {
+        return this.modelMapper.map(loginUser, UserResponse.class);
+    }
+
 
 }

--- a/app/src/test/java/dev/abelab/hack/dena/logic/UserLogic_UT.java
+++ b/app/src/test/java/dev/abelab/hack/dena/logic/UserLogic_UT.java
@@ -3,17 +3,11 @@ package dev.abelab.hack.dena.logic;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.*;
-import static org.junit.jupiter.params.provider.Arguments.*;
 import static org.mockito.ArgumentMatchers.*;
-
-import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 import mockit.Expectations;
 import mockit.Injectable;
 import mockit.Tested;
@@ -24,7 +18,6 @@ import dev.abelab.hack.dena.db.entity.UserSample;
 import dev.abelab.hack.dena.repository.UserRepository;
 import dev.abelab.hack.dena.property.JwtProperty;
 import dev.abelab.hack.dena.exception.ErrorCode;
-import dev.abelab.hack.dena.exception.BaseException;
 import dev.abelab.hack.dena.exception.UnauthorizedException;
 
 public class UserLogic_UT extends AbstractLogic_UT {


### PR DESCRIPTION
This PR fixes #14 

## API仕様

```
/api/users/me
GET
```

### レスポンスボディ

```json
{
    "id": 0,
    "email": "string",
    "firstName": "string",
    "lastName": "string"
}
```